### PR TITLE
Add CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,43 @@
+version: 2.1
+
+jobs:
+  test:
+    docker:
+      - image: cimg/go:1.18
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-go-mod-{{ checksum "go.sum" }}
+      - run: go test -v ./...
+      - save_cache:
+          key: v1-go-mod-{{ checksum "go.sum" }}
+          paths:
+            - /home/circleci/go/pkg/mod
+
+  publish_github:
+    docker:
+      - image: cibuilds/github:0.13.0
+    steps:
+      - run:
+          name: "Publish Release on GitHub"
+          command: |
+            echo "Creating GitHub release for tag ${CIRCLE_TAG}"
+            ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG}
+
+workflows:
+  build:
+    jobs:
+      - test:
+          filters:
+            tags:
+              only: /.*/
+      - publish_github:
+          context: Honeycomb Secrets for Public Repos
+          requires:
+            - test
+          filters:
+            tags:
+              only: /^v[0-9].*/
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Setups up CircleCI to run tests for each new PR and add support for creating github releases on new git tags.

- Closes #1 

## Short description of the changes
- Adds .circleci/config.yml with instructions to test all commits and create github release for new git tags

NOTE: This is based on the branch for #17 because it would fail without a base go module to test Once that PR is merged, this will auto-redirect to main.