### PR TITLE
Default service name to unknown_service when not set

### DIFF
--- a/honeycomb.go
+++ b/honeycomb.go
@@ -100,7 +100,7 @@ func getVendorOptionSetters() []launcher.Option {
 		}
 	}
 	if serviceName := os.Getenv("OTEL_SERVICE_NAME"); serviceName == "" {
-		opts = append(opts, launcher.WithServiceName("unknown_service:golang"))
+		opts = append(opts, launcher.WithServiceName("unknown_service:go"))
 	}
 	return opts
 }

--- a/honeycomb_test.go
+++ b/honeycomb_test.go
@@ -177,5 +177,5 @@ func TestServiceNameDefaultsToUnknownServiceWhenNotSet(t *testing.T) {
 	for _, setter := range getVendorOptionSetters() {
 		setter(config)
 	}
-	assert.Equal(t, "unknown_service:golang", config.ServiceName)
+	assert.Equal(t, "unknown_service:go", config.ServiceName)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜 
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

<please describe the issue>
Honeycomb needs a service name when processing incoming events. We should set a default service name if one is not set by the user.

## Short description of the changes
Check if the env var OTEL_SERVICE_NAME is set, and it not, set it to `unknown_service:golang`.

## How to verify that this has the expected result
When not setting a service name, it defaults to `unknown_service:golang`.