### PR TITLE
Update sample rate env var

### DIFF
--- a/honeycomb.go
+++ b/honeycomb.go
@@ -87,7 +87,7 @@ func getVendorOptionSetters() []launcher.Option {
 	if dataset := os.Getenv("HONEYCOMB_DATASET"); dataset != "" {
 		opts = append(opts, WithDataset(dataset))
 	}
-	if sampleRateStr := os.Getenv("HONEYCOMB_SAMPLE_RATE"); sampleRateStr != "" {
+	if sampleRateStr := os.Getenv("SAMPLE_RATE"); sampleRateStr != "" {
 		sampleRate, err := strconv.Atoi(sampleRateStr)
 		if err == nil {
 			opts = append(opts, WithSampler(sampleRate))

--- a/honeycomb_test.go
+++ b/honeycomb_test.go
@@ -150,7 +150,7 @@ func TestConfigureDeterministicSampler(t *testing.T) {
 	assert.Equal(t, "AlwaysOnSampler", config.Sampler.Description())
 
 	// set env var - should have deterministic sampler
-	t.Setenv("HONEYCOMB_SAMPLE_RATE", "1")
+	t.Setenv("SAMPLE_RATE", "1")
 	config = freshConfig()
 	for _, setter := range getVendorOptionSetters() {
 		setter(config)


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜 
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
The env var we use to detect sample rate for configuring the deterministic sampler should is wrong.

## Short description of the changes
- Update the env var to get sample rate to `SAMPLE_RATE`.

## How to verify that this has the expected result
Setting the env var `SAMPLE_RATE` configures the deterministic sampler correctly.