### PR TITLE
Update debug env var

### DIFF
--- a/honeycomb.go
+++ b/honeycomb.go
@@ -93,7 +93,7 @@ func getVendorOptionSetters() []launcher.Option {
 			opts = append(opts, WithSampler(sampleRate))
 		}
 	}
-	if enabledStr := os.Getenv("OTEL_EXPORTER_DEBUG_ENABLED"); enabledStr != "" {
+	if enabledStr := os.Getenv("DEBUG"); enabledStr != "" {
 		enabled, _ := strconv.ParseBool(enabledStr)
 		if enabled {
 			opts = append(opts, WithDebugSpanExporter())

--- a/honeycomb_test.go
+++ b/honeycomb_test.go
@@ -160,7 +160,7 @@ func TestConfigureDeterministicSampler(t *testing.T) {
 
 func TestSettingExporterDebugEnabledAddsDebugExporter(t *testing.T) {
 	config := freshConfig()
-	t.Setenv("OTEL_EXPORTER_DEBUG_ENABLED", "true")
+	t.Setenv("DEBUG", "true")
 
 	for _, setter := range getVendorOptionSetters() {
 		setter(config)


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜 
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
The debug env var we use to configure the stdout exporter is wrong and should be updated.

## Short description of the changes
- Update the env var we look for to set add the stdout exporter to `DEBUG`.

## How to verify that this has the expected result
 Setting the `DEBUG` env var configures the stdout exporter.