### PR TITLE
Update otel-go-contrib launcher

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/honeycombio/otel/honeycomb
 go 1.18
 
 require (
-	github.com/honeycombio/opentelemetry-go-contrib/launcher v0.0.0-20220810120809-e5e9e5f189e5
+	github.com/honeycombio/opentelemetry-go-contrib/launcher v0.0.0-20220811154106-5ed276335ffe
 	github.com/stretchr/testify v1.8.0
 	go.opentelemetry.io/otel v1.9.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 h1:BZHcxBETFHIdVyhyEfOvn/RdU/QG
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/honeycombio/opentelemetry-go-contrib/launcher v0.0.0-20220810120809-e5e9e5f189e5 h1:iyDcUlxHTG7DGeQzzqlQMTQylnd48QnOqYOevBHTGqg=
-github.com/honeycombio/opentelemetry-go-contrib/launcher v0.0.0-20220810120809-e5e9e5f189e5/go.mod h1:RQL6cMY8S6SD3hx1i9ssKrQCHY6xgZWP+MFtYePjukc=
+github.com/honeycombio/opentelemetry-go-contrib/launcher v0.0.0-20220811154106-5ed276335ffe h1:izmf3EBrdjmnvHBpbGU8Jxpe5JnmyiJeI/xdyKBTPbE=
+github.com/honeycombio/opentelemetry-go-contrib/launcher v0.0.0-20220811154106-5ed276335ffe/go.mod h1:RQL6cMY8S6SD3hx1i9ssKrQCHY6xgZWP+MFtYePjukc=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜 
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Updates the otel-go-contrib/launcher module to latest.

## Short description of the changes
- Update otel-go-contrib/launcher package to https://github.com/honeycombio/opentelemetry-go-contrib/commit/5ed276335ffe5bfbcc7421754d93632e00a424b2

## How to verify that this has the expected result
The latest launcher version is now being used.