### PR TITLE
Set log level to debug when debug option is set

### DIFF
--- a/honeycomb.go
+++ b/honeycomb.go
@@ -97,6 +97,7 @@ func getVendorOptionSetters() []launcher.Option {
 		enabled, _ := strconv.ParseBool(enabledStr)
 		if enabled {
 			opts = append(opts, WithDebugSpanExporter())
+			opts = append(opts, launcher.WithLogLevel("debug"))
 		}
 	}
 	if serviceName := os.Getenv("OTEL_SERVICE_NAME"); serviceName == "" {

--- a/honeycomb_test.go
+++ b/honeycomb_test.go
@@ -179,3 +179,13 @@ func TestServiceNameDefaultsToUnknownServiceWhenNotSet(t *testing.T) {
 	}
 	assert.Equal(t, "unknown_service:go", config.ServiceName)
 }
+
+func TestSettingDebugAlsoSetsLogLevelToDebug(t *testing.T) {
+	t.Setenv("DEBUG", "true")
+	launcher.ValidateConfig = func(c *launcher.Config) error {
+		assert.Equal(t, c.LogLevel, "debug")
+		return nil
+	}
+	_, err := launcher.ConfigureOpenTelemetry()
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜 
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

When the `DEBUG` env var is set, it should set the log level to "debug" too.

- Closes #51 

## Short description of the changes
- When `DEBUG` env var is detected, set log level to "debug"
