### PR TITLE
Set base exporter endpoint when setting up vendor opts

### DIFF
--- a/honeycomb.go
+++ b/honeycomb.go
@@ -44,8 +44,7 @@ func WithHoneycomb() launcher.Option {
 	return func(c *launcher.Config) {
 		c.ResourceAttributes[honeycombDistroVersionKey] = Version
 		c.ResourceAttributes[honeycombDistroRuntimeVersionKey] = runtime.Version()
-		c.TracesExporterEndpoint = DefaultSpanExporterEndpoint
-		c.MetricsExporterEndpoint = DefaultMetricExporterEndpoint
+		c.ExporterEndpoint = DefaultSpanExporterEndpoint
 	}
 }
 

--- a/honeycomb_test.go
+++ b/honeycomb_test.go
@@ -70,11 +70,8 @@ func TestSetVendorOptions(t *testing.T) {
 				setter(aConfig)
 			}
 
-			assert.Equal(t, DefaultSpanExporterEndpoint, aConfig.TracesExporterEndpoint,
-				"Trace data should be configured to target the Honeycomb API endpoint.",
-			)
-			assert.Equal(t, DefaultMetricExporterEndpoint, aConfig.MetricsExporterEndpoint,
-				"Metric data should be configured to target the Honeycomb API endpoint.",
+			assert.Equal(t, DefaultSpanExporterEndpoint, aConfig.ExporterEndpoint,
+				"Trace & metric data should be configured to target the Honeycomb API endpoint.",
 			)
 			assert.Equal(t, tC.expectedHeaders, aConfig.Headers)
 		})


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜 
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

The launcher base config has a generic Exporter endpoint that we can set instead of the specific traces and metrics endpoints. Traces and metrics endpoints fallback to the generic value if not set directly.

- Closes #50
- Closes #59

## Short description of the changes
- Set the launcher config's ExporterEndpoint value instead of both TracesExporterEndpoint and MetricsExporterEndpoint
- Update existing unit test to verify the value has been set correctly

## How to verify that this has the expected result
- When using the distro, both traces and metrics data should continue to set to honeycomb without issue. If a specific traces or metric endpoint is set, it data should be sent there instead.