### PR TITLE
More descriptive errors

### DIFF
--- a/common.go
+++ b/common.go
@@ -1,0 +1,7 @@
+package honeycomb
+
+const (
+	noApiKeyDetectedMessage string = "Missing an API Key!\nConfigure via HONEYCOMB_API_KEY environment variable, or in code."
+	classicKeyMissingDatasetMessage string = "Honeycomb Classic API Key detected!\nYour API key: %s requires a dataset to be configured.\nConfigure via HONEYCOMB_DATASET or in code."
+	dontSetADatasetMessageMessage string = "Dataset detected! Datasets are a Honeycomb Classic configuration value.\nUnset HONEYCOMB_DATASET or remove configuration code that sets a dataset."
+)

--- a/honeycomb.go
+++ b/honeycomb.go
@@ -111,14 +111,14 @@ func validateConfig(c *launcher.Config) error {
 
 	switch len(apikey) {
 	case 0:
-		return fmt.Errorf("missing x-honeycomb-team header")
+		return fmt.Errorf(noApiKeyDetectedMessage)
 	case 32: // classic
 		if dataset == "" {
-			return fmt.Errorf("missing x-honeycomb-dataset header")
+			return fmt.Errorf(classicKeyMissingDatasetMessage, apikey)
 		}
 	default:
 		if dataset != "" {
-			return fmt.Errorf("do not include dataset header for non-classic API keys")
+			return fmt.Errorf(dontSetADatasetMessageMessage)
 		}
 	}
 	return nil

--- a/honeycomb_test.go
+++ b/honeycomb_test.go
@@ -104,19 +104,19 @@ func TestValidateConfig(t *testing.T) {
 			desc:          "modern API key and a dataset",
 			apikey:        "123456789012345678901",
 			dataset:       "no thank you",
-			expectedError: fmt.Errorf("do not include dataset header for non-classic API keys"),
+			expectedError: fmt.Errorf(dontSetADatasetMessageMessage),
 		},
 		{
 			desc:          "empty API key",
 			apikey:        "",
 			dataset:       "doesn't matter",
-			expectedError: fmt.Errorf("missing x-honeycomb-team header"),
+			expectedError: fmt.Errorf(noApiKeyDetectedMessage),
 		},
 		{
 			desc:          "classic API key and no dataset",
 			apikey:        "12345678901234567890123456789012",
 			dataset:       "",
-			expectedError: fmt.Errorf("missing x-honeycomb-dataset header"),
+			expectedError: fmt.Errorf(classicKeyMissingDatasetMessage, "12345678901234567890123456789012"),
 		},
 	}
 	for _, tC := range testCases {


### PR DESCRIPTION
This came about when I was playing with the distro last week, running into several issues across different environments (and confusingly, the environment that's a classic environment...). I was tripped up by the use of terms related to direct HTTP headers since I never actually set this values. I also struggled to see the difference between `x-honeycomb-team` and `x-honeycomb-dataset`, thinking to myself "but I have an API key!".

Anyways, here's some proposed changes to the configuration errors.