### PR TITLE
feat: add OTLP version header

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,8 @@
 # Creating a new release
 
 1. Update the version string in `version.go`.
-2. Add new release notes to the Changelog and Open a PR with those changes.
-2. Once the above PR is merged, tag `main` with the new version, e.g. `v0.1.0`, and push the tags. This will kick off a CI workflow, which will publish a draft GitHub release.
-3. Update Release Notes on the new draft GitHub release using the Changelog entry, and publish that.
+1. If this release includes an upgrade to the underlying OTLP proto version, update `otlpProtoVersionValue` in `honeycomb.go` (run `go list -m all` to see which version was selected for `go.opentelemetry.io/proto/otlp`)
+1. Add new release notes to the Changelog.
+1. Open a PR with above changes.
+1. Once the above PR is merged, tag `main` with the new version, e.g. `v0.1.0`, and push the tags. This will kick off a CI workflow, which will publish a draft GitHub release.
+1. Update Release Notes on the new draft GitHub release using the Changelog entry, and publish that as Pre-release.

--- a/honeycomb.go
+++ b/honeycomb.go
@@ -32,6 +32,8 @@ const (
 	honeycombDatasetHeader           = "x-honeycomb-dataset"
 	honeycombDistroVersionKey        = "honeycomb.distro.version"
 	honeycombDistroRuntimeVersionKey = "honeycomb.distro.runtime_version"
+	otlpProtoVersionHeader           = "x-otlp-version"
+	otlpProtoVersionValue            = "0.18.0"
 )
 
 func init() {
@@ -44,6 +46,7 @@ func WithHoneycomb() launcher.Option {
 	return func(c *launcher.Config) {
 		c.ResourceAttributes[honeycombDistroVersionKey] = Version
 		c.ResourceAttributes[honeycombDistroRuntimeVersionKey] = runtime.Version()
+		c.Headers[otlpProtoVersionHeader] = otlpProtoVersionValue
 		c.ExporterEndpoint = DefaultSpanExporterEndpoint
 	}
 }

--- a/honeycomb_test.go
+++ b/honeycomb_test.go
@@ -152,6 +152,15 @@ func TestHoneycombResourceAttributesAreSet(t *testing.T) {
 	assert.Equal(t, runtime.Version(), config.ResourceAttributes["honeycomb.distro.runtime_version"])
 }
 
+func TestOTLPVersionIsSet(t *testing.T) {
+	config := freshConfig()
+	for _, setter := range getVendorOptionSetters() {
+		setter(config)
+	}
+
+	assert.Equal(t, otlpProtoVersionValue, config.Headers[otlpProtoVersionHeader])
+}
+
 func TestConfigureDeterministicSampler(t *testing.T) {
 	// no env var - should use default sampler
 	config := freshConfig()

--- a/honeycomb_test.go
+++ b/honeycomb_test.go
@@ -64,13 +64,16 @@ func TestSetVendorOptions(t *testing.T) {
 			expectedHeaders: map[string]string{
 				honeycombApiKeyHeader:  "atestkey",
 				honeycombDatasetHeader: "adataset",
+				otlpProtoVersionHeader: otlpProtoVersionValue,
 			},
 		},
 		{
-			desc:            "no API key or dataset",
-			apikey:          "",
-			dataset:         "",
-			expectedHeaders: map[string]string{},
+			desc:    "no API key or dataset",
+			apikey:  "",
+			dataset: "",
+			expectedHeaders: map[string]string{
+				otlpProtoVersionHeader: otlpProtoVersionValue,
+			},
 		},
 	}
 	for _, tC := range testCases {
@@ -150,15 +153,6 @@ func TestHoneycombResourceAttributesAreSet(t *testing.T) {
 
 	assert.Equal(t, Version, config.ResourceAttributes["honeycomb.distro.version"])
 	assert.Equal(t, runtime.Version(), config.ResourceAttributes["honeycomb.distro.runtime_version"])
-}
-
-func TestOTLPVersionIsSet(t *testing.T) {
-	config := freshConfig()
-	for _, setter := range getVendorOptionSetters() {
-		setter(config)
-	}
-
-	assert.Equal(t, otlpProtoVersionValue, config.Headers[otlpProtoVersionHeader])
 }
 
 func TestConfigureDeterministicSampler(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜 
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

We want to know which OTLP version is used so we can safely upgrade on the consumer side.

- Closes #63 

## Short description of the changes

Adding the extra `x-otlp-version` header when configuring the distro metadata.

## How to verify that this has the expected result

Funny/sad discovery: we can't actually see the `x-otlp-version` in our own telemetry because our instrumentation doesn't capture it :lolsob: Will create follow-up issue to add that.

For now, I was able to see the header in incoming gRPC metadata in local shepherd:
  
![Screen Shot 2022-08-17 at 7 12 51 PM](https://user-images.githubusercontent.com/6738917/185260071-9a9eaeb4-f8ad-4a59-86c3-5ad721a7e54e.png)

