### PR TITLE
Add support for Honeycomb endpoint environment variables

### DIFF
--- a/honeycomb.go
+++ b/honeycomb.go
@@ -80,6 +80,15 @@ func getVendorOptionSetters() []launcher.Option {
 	opts := []launcher.Option{
 		WithHoneycomb(),
 	}
+	if endpoint := os.Getenv("HONEYCOMB_API_ENDPOINT"); endpoint != "" {
+		opts = append(opts, launcher.WithExporterEndpoint(endpoint))
+	}
+	if endpoint := os.Getenv("HONEYCOMB_TRACES_API_ENDPOINT"); endpoint != "" {
+		opts = append(opts, launcher.WithSpanExporterEndpoint(endpoint))
+	}
+	if endpoint := os.Getenv("HONEYCOMB_METRICS_API_ENDPOINT"); endpoint != "" {
+		opts = append(opts, launcher.WithMetricExporterEndpoint(endpoint))
+	}
 	if apikey := os.Getenv("HONEYCOMB_API_KEY"); apikey != "" {
 		opts = append(opts, WithApiKey(apikey))
 	}

--- a/honeycomb_test.go
+++ b/honeycomb_test.go
@@ -200,3 +200,18 @@ func TestSettingDebugAlsoSetsLogLevelToDebug(t *testing.T) {
 	_, err := launcher.ConfigureOpenTelemetry()
 	assert.Nil(t, err)
 }
+
+func TestCanSetEndpointsUsingHoneycombEnvVars(t *testing.T) {
+	t.Setenv("HONEYCOMB_API_ENDPOINT", "generic-endpoint")
+	t.Setenv("HONEYCOMB_TRACES_API_ENDPOINT", "traces-endpoint")
+	t.Setenv("HONEYCOMB_METRICS_API_ENDPOINT", "metrics-endpoint")
+
+	launcher.ValidateConfig = func(c *launcher.Config) error {
+		assert.Equal(t, "generic-endpoint", c.ExporterEndpoint)
+		assert.Equal(t, "traces-endpoint", c.TracesExporterEndpoint)
+		assert.Equal(t, "metrics-endpoint", c.MetricsExporterEndpoint)
+		return nil
+	}
+	_, err := launcher.ConfigureOpenTelemetry()
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜 
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Adds support for reading and applying honeycomb endpoint environment variables, `HONEYCOMB_API_ENDPOINT`, `HONEYCOMB_TRACES_API_ENDPOINT` and `HONEYCOMB_METRICS_API_ENDPOINT`.

- Closes #62 

## Short description of the changes
- Read and apply the environment variables during `setVendorOptions`
- Add unit test to verify env vars are read and applied to the config

## How to verify that this has the expected result
Setting the honeycomb specific env vars results in the distro sending telemetry to the provided endpoint.