### PR TITLE
maint: add test matrix and nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,20 @@
 version: 2.1
 
+matrix_goversions: &matrix_goversions
+  matrix:
+    parameters:
+      goversion: ["17", "18", "19"]
+
+default_goversion: &default_goversion "18"
+
 jobs:
   test:
+    parameters:
+      goversion:
+        type: string
+        default: *default_goversion
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.<< parameters.goversion >>
     steps:
       - checkout
       - restore_cache:
@@ -26,9 +37,22 @@ jobs:
             ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG}
 
 workflows:
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - test:
+          <<: *matrix_goversions
+
   build:
     jobs:
       - test:
+          <<: *matrix_goversions
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜 
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

We typically test across supported language versions in CI. We also typically run a nightly build.

## Short description of the changes

Do the things. Testing Go 1.17, 1.18 and 1.19 which are the currently supported versions.

## How to verify that this has the expected result

https://app.circleci.com/pipelines/github/honeycombio/honeycomb-opentelemetry-go/86/workflows/d66246de-5488-467b-be07-42d3978e17ce
  
