### PR TITLE
Disable metrics by default

### DIFF
--- a/honeycomb.go
+++ b/honeycomb.go
@@ -114,6 +114,15 @@ func getVendorOptionSetters() []launcher.Option {
 	if serviceName := os.Getenv("OTEL_SERVICE_NAME"); serviceName == "" {
 		opts = append(opts, launcher.WithServiceName("unknown_service:go"))
 	}
+	// default metrics off unless explicity enabled
+	metricsEnabled := false
+	if enabledStr := os.Getenv("OTEL_METRICS_ENABLED"); enabledStr != "" {
+		enabled, _ := strconv.ParseBool(enabledStr)
+		if enabled {
+			metricsEnabled = true
+		}
+	}
+	opts = append(opts, launcher.WithMetricsEnabled(metricsEnabled))
 	return opts
 }
 

--- a/honeycomb_test.go
+++ b/honeycomb_test.go
@@ -218,3 +218,22 @@ func TestCanSetEndpointsUsingHoneycombEnvVars(t *testing.T) {
 	_, err := launcher.ConfigureOpenTelemetry()
 	assert.Nil(t, err)
 }
+
+func TestMetricsAreDisabledByDefault(t *testing.T) {
+	// disabled by default
+	launcher.ValidateConfig = func(c *launcher.Config) error {
+		assert.False(t, c.MetricsEnabled)
+		return nil
+	}
+	_, err := launcher.ConfigureOpenTelemetry()
+	assert.Nil(t, err)
+
+	// can be enabled
+	t.Setenv("OTEL_METRICS_ENABLED", "true")
+	launcher.ValidateConfig = func(c *launcher.Config) error {
+		assert.True(t, c.MetricsEnabled)
+		return nil
+	}
+	_, err = launcher.ConfigureOpenTelemetry()
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜 
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Not all Honeycomb users get access to metrics and so it should be an opt-in feature. This change makes metrics disabled by default and can be enabled by either setting the env var `OTEL_METRICS_ENABLED` or using `launcher.WithMetricsEnabled(true)` option.

- Closes #69 

## Short description of the changes
- Default metrics to be disabled
- Check OTEL_METRICS_ENABLED to see if it should be enabled
- Add unit test

## How to verify that this has the expected result
The distro will not attempt to send metrics unless they are explicitly enabled.