### PR TITLE
Add support for separate traces and metrics API key and dataset

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/honeycombio/honeycomb-opentelemetry-go
 go 1.18
 
 require (
-	github.com/honeycombio/opentelemetry-go-contrib/launcher v0.0.0-20220811154106-5ed276335ffe
+	github.com/honeycombio/opentelemetry-go-contrib/launcher v0.0.0-20220823150308-452920706808
 	github.com/stretchr/testify v1.8.0
 	go.opentelemetry.io/otel v1.9.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/honeycombio/honeycomb-opentelemetry-go
 go 1.18
 
 require (
-	github.com/honeycombio/opentelemetry-go-contrib/launcher v0.0.0-20220823150308-452920706808
+	github.com/honeycombio/opentelemetry-go-contrib/launcher v0.0.0-20220824095536-e0b3dd3fbfe7
 	github.com/stretchr/testify v1.8.0
 	go.opentelemetry.io/otel v1.9.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 h1:BZHcxBETFHIdVyhyEfOvn/RdU/QG
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/honeycombio/opentelemetry-go-contrib/launcher v0.0.0-20220823150308-452920706808 h1:hRz4/XwNa5LaWI4+XlTmvP2QvDoqt74nmTBrw/W1QpU=
-github.com/honeycombio/opentelemetry-go-contrib/launcher v0.0.0-20220823150308-452920706808/go.mod h1:RQL6cMY8S6SD3hx1i9ssKrQCHY6xgZWP+MFtYePjukc=
+github.com/honeycombio/opentelemetry-go-contrib/launcher v0.0.0-20220824095536-e0b3dd3fbfe7 h1:s3EUCVM97Q860+VMdh4og/jUx+aiIx1QirNT90OUhUg=
+github.com/honeycombio/opentelemetry-go-contrib/launcher v0.0.0-20220824095536-e0b3dd3fbfe7/go.mod h1:RQL6cMY8S6SD3hx1i9ssKrQCHY6xgZWP+MFtYePjukc=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 h1:BZHcxBETFHIdVyhyEfOvn/RdU/QG
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/honeycombio/opentelemetry-go-contrib/launcher v0.0.0-20220811154106-5ed276335ffe h1:izmf3EBrdjmnvHBpbGU8Jxpe5JnmyiJeI/xdyKBTPbE=
-github.com/honeycombio/opentelemetry-go-contrib/launcher v0.0.0-20220811154106-5ed276335ffe/go.mod h1:RQL6cMY8S6SD3hx1i9ssKrQCHY6xgZWP+MFtYePjukc=
+github.com/honeycombio/opentelemetry-go-contrib/launcher v0.0.0-20220823150308-452920706808 h1:hRz4/XwNa5LaWI4+XlTmvP2QvDoqt74nmTBrw/W1QpU=
+github.com/honeycombio/opentelemetry-go-contrib/launcher v0.0.0-20220823150308-452920706808/go.mod h1:RQL6cMY8S6SD3hx1i9ssKrQCHY6xgZWP+MFtYePjukc=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=

--- a/honeycomb.go
+++ b/honeycomb.go
@@ -58,10 +58,38 @@ func WithApiKey(apikey string) launcher.Option {
 	}
 }
 
+// WithTracesApiKey() sets the authorization header appropriately for sending traces telemetry to Honeycomb's API endpoint.
+func WithTracesApiKey(apikey string) launcher.Option {
+	return func(c *launcher.Config) {
+		c.TracesHeaders[honeycombApiKeyHeader] = apikey
+	}
+}
+
+// WithMetricsApiKey() sets the authorization header appropriately for sending metrics telemetry to Honeycomb's API endpoint.
+func WithMetricsApiKey(apikey string) launcher.Option {
+	return func(c *launcher.Config) {
+		c.MetricsHeaders[honeycombApiKeyHeader] = apikey
+	}
+}
+
 // WithDataset() sets the header for routing telemetry to a named dataset at Honeycomb. (For trace data in Classic teams and for metrics only.)
 func WithDataset(dataset string) launcher.Option {
 	return func(c *launcher.Config) {
 		c.Headers[honeycombDatasetHeader] = dataset
+	}
+}
+
+// WithTracesDataset() sets the header for routing traces telemetry to a named dataset at Honeycomb.
+func WithTracesDataset(dataset string) launcher.Option {
+	return func(c *launcher.Config) {
+		c.TracesHeaders[honeycombDatasetHeader] = dataset
+	}
+}
+
+// WithMetricsDataset() sets the header for routing metrics telemetry to a named dataset at Honeycomb.
+func WithMetricsDataset(dataset string) launcher.Option {
+	return func(c *launcher.Config) {
+		c.MetricsHeaders[honeycombDatasetHeader] = dataset
 	}
 }
 
@@ -95,8 +123,20 @@ func getVendorOptionSetters() []launcher.Option {
 	if apikey := os.Getenv("HONEYCOMB_API_KEY"); apikey != "" {
 		opts = append(opts, WithApiKey(apikey))
 	}
+	if apikey := os.Getenv("HONEYCOMB_TRACES_APIKEY"); apikey != "" {
+		opts = append(opts, WithTracesApiKey(apikey))
+	}
+	if apikey := os.Getenv("HONEYCOMB_METRICS_APIKEY"); apikey != "" {
+		opts = append(opts, WithMetricsApiKey(apikey))
+	}
 	if dataset := os.Getenv("HONEYCOMB_DATASET"); dataset != "" {
 		opts = append(opts, WithDataset(dataset))
+	}
+	if dataset := os.Getenv("HONEYCOMB_TRACES_DATASET"); dataset != "" {
+		opts = append(opts, WithTracesDataset(dataset))
+	}
+	if dataset := os.Getenv("HONEYCOMB_METRICS_DATASET"); dataset != "" {
+		opts = append(opts, WithMetricsDataset(dataset))
 	}
 	if sampleRateStr := os.Getenv("SAMPLE_RATE"); sampleRateStr != "" {
 		sampleRate, err := strconv.Atoi(sampleRateStr)

--- a/honeycomb.go
+++ b/honeycomb.go
@@ -87,10 +87,10 @@ func getVendorOptionSetters() []launcher.Option {
 		opts = append(opts, launcher.WithExporterEndpoint(endpoint))
 	}
 	if endpoint := os.Getenv("HONEYCOMB_TRACES_API_ENDPOINT"); endpoint != "" {
-		opts = append(opts, launcher.WithSpanExporterEndpoint(endpoint))
+		opts = append(opts, launcher.WithTracesExporterEndpoint(endpoint))
 	}
 	if endpoint := os.Getenv("HONEYCOMB_METRICS_API_ENDPOINT"); endpoint != "" {
-		opts = append(opts, launcher.WithMetricExporterEndpoint(endpoint))
+		opts = append(opts, launcher.WithMetricsExporterEndpoint(endpoint))
 	}
 	if apikey := os.Getenv("HONEYCOMB_API_KEY"); apikey != "" {
 		opts = append(opts, WithApiKey(apikey))

--- a/honeycomb_test.go
+++ b/honeycomb_test.go
@@ -33,7 +33,8 @@ func freshConfig() *launcher.Config {
 		ServiceName:                     "",
 		ServiceVersion:                  "",
 		Headers:                         map[string]string{},
-		HeadersFromEnv:                  "",
+		TracesHeaders:                   map[string]string{},
+		MetricsHeaders:                  map[string]string{},
 		MetricsExporterEndpoint:         "",
 		MetricsExporterEndpointInsecure: false,
 		MetricsEnabled:                  false,
@@ -213,6 +214,23 @@ func TestCanSetEndpointsUsingHoneycombEnvVars(t *testing.T) {
 		assert.Equal(t, "generic-endpoint", c.ExporterEndpoint)
 		assert.Equal(t, "traces-endpoint", c.TracesExporterEndpoint)
 		assert.Equal(t, "metrics-endpoint", c.MetricsExporterEndpoint)
+		return nil
+	}
+	_, err := launcher.ConfigureOpenTelemetry()
+	assert.Nil(t, err)
+}
+
+func TestCanSetTracesAndMetricsSpecificHeaders(t *testing.T) {
+	t.Setenv("HONEYCOMB_TRACES_APIKEY", "traces-apikey")
+	t.Setenv("HONEYCOMB_TRACES_DATASET", "traces-dataset")
+	t.Setenv("HONEYCOMB_METRICS_APIKEY", "metrics-apikey")
+	t.Setenv("HONEYCOMB_METRICS_DATASET", "metrics-dataset")
+
+	launcher.ValidateConfig = func(c *launcher.Config) error {
+		assert.Equal(t, "traces-apikey", c.TracesHeaders[honeycombApiKeyHeader])
+		assert.Equal(t, "traces-dataset", c.TracesHeaders[honeycombDatasetHeader])
+		assert.Equal(t, "metrics-apikey", c.MetricsHeaders[honeycombApiKeyHeader])
+		assert.Equal(t, "metrics-dataset", c.MetricsHeaders[honeycombDatasetHeader])
 		return nil
 	}
 	_, err := launcher.ConfigureOpenTelemetry()


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜 
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
It can be useful to send telemetry to different endpoints, eg direct vs through a proxy (refinery / collector). This often requires different endpoints and headers. Headers were shared between traces and metrics exporters which meant it wasn't possible.

This PR utilises the new launcher options to set traces and metrics specific headers.

- Closes #71 
- Blocked on https://github.com/honeycombio/opentelemetry-go-contrib/pull/655

## Short description of the changes
- Introduce options to set traces and metrics api key and datasets, both by env var and launcher options
- Add unit tests

## How to verify that this has the expected result
You can send traces and metrics telemetry with different api keys and dataset headers.