### PR TITLE
Remove timestamp field from example trigger hook

### DIFF
--- a/examples/webhook-listener-triggers/README.md
+++ b/examples/webhook-listener-triggers/README.md
@@ -42,8 +42,7 @@ Here's an example of a notification that Honeycomb Triggers would send and this 
       "Result": 5
     }
   ],
-  "trigger_url": "https://ui.honeycomb.io/test-team/environments/telemetry/datasets/webhook-listener-triggers/triggers/abcdef",
-  "timestamp": "2022-08-20T16:25:18.73874-04:00"
+  "trigger_url": "https://ui.honeycomb.io/test-team/environments/telemetry/datasets/webhook-listener-triggers/triggers/abcdef"
 }
 ```
 


### PR DESCRIPTION
#68 added a timestamp field to the example readme which is actually not passed as part of the trigger, and is added by the go program. This is very confusing as this example is linked from the Honeycomb documentation as an example of the trigger payload! This removes that field from the readme but doesn't touch the go program.