### PR TITLE
maint: update readme with latest otel version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It makes getting started with OpenTelemetry and Honeycomb easier!
 
 Latest release built with:
 
-- [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.9.0) version v1.9.0
+- [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.11.1) version v1.11.1/v0.33.0
 
 ## Why would I want to use this?
 
@@ -23,9 +23,9 @@ Latest release built with:
 
 ## Where's most of the code?
 
-This package is a _layer_ on top of the core package, which you can find in our [fork of the opentelemetry-go-contrib repo](https://github.com/honeycombio/opentelemetry-go-contrib/tree/launcher/launcher). As such, it only containts Honeycomb-specific functionality.
+This package is a _layer_ on top of the core package, which you can find in our [fork of the opentelemetry-go-contrib repo](https://github.com/honeycombio/opentelemetry-go-contrib/tree/launcher/launcher). As such, it only contains Honeycomb-specific functionality.
 
-Our immedate goal is that our fork lives upstream in the opentelemetry-go-contrib project as a blessed, vendor-neutral way to get started.
+Our immediate goal is that our fork lives upstream in the opentelemetry-go-contrib project as a blessed, vendor-neutral way to get started.
 
 ## License
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,6 +2,7 @@
 
 1. Update the version string in `version.go`.
 1. If this release includes an upgrade to the underlying OTLP proto version, update `otlpProtoVersionValue` in `honeycomb.go` (run `go list -m all` to see which version was selected for `go.opentelemetry.io/proto/otlp`)
+1. If this release updates OTel versions, update "OTel version this is built with" in the README.md
 1. Add new release notes to the Changelog.
 1. Open a PR with above changes.
 1. Once the above PR is merged, tag `main` with the new version, e.g. `v0.1.0`, and push the tags. This will kick off a CI workflow, which will publish a draft GitHub release.


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜 
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Readme lists which OTel version is currently bundled in the distro

## Short description of the changes

- fix typos
- add releasing step to update otel version in readme

  
