### PR TITLE
rel: Prepare v0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Honeycomb OpenTelemetry Distro Changelog
 
+## v0.4.0 (2023-01-04)
+
+### Fixes
+
+- Don't error on misconfiguration; warn instead (#98) | [@cartermp](https://github.com/cartermp)
+
+### Maintenance
+
+- Update Launcher and OTel packages (#100) | [@MikeGoldsmith](https://github.com/MikeGoldsmith)
+- Fix typo in test file (#99) | [@JamieDanielson](https://github.com/jamiedanielson)
+- Update readme with latest otel version (#88) | [@vreynolds](https://github.com/vreynolds)
+- Update validate PR title workflow (#91) | [@pkanal](https://github.com/pkanal)
+- Validate PR title (#90) | [@pkanal](https://github.com/pkanal)
+- Give dependabot PRs a better title (#93) | [@kentquirk](https://github.com/kentquirk)
+
 ## v0.3.0 (2022-10-31)
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It makes getting started with OpenTelemetry and Honeycomb easier!
 
 Latest release built with:
 
-- [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.11.1) version v1.11.1/v0.33.0
+- [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.11.2) version v1.11.2/v0.34.0
 
 ## Why would I want to use this?
 

--- a/version.go
+++ b/version.go
@@ -15,5 +15,5 @@
 package honeycomb
 
 var (
-	Version string = "0.3.0"
+	Version string = "0.4.0"
 )


### PR DESCRIPTION
## Which problem is this PR solving?
Prepares the v0.4.0 release.

## Short description of the changes
- Updates version to 0.4.0 in version.go
- Adds changelog entry
- Updates OTel SDK version in README
