### PR TITLE
fix: Use configured logger to print messages

### DIFF
--- a/honeycomb.go
+++ b/honeycomb.go
@@ -15,7 +15,6 @@
 package honeycomb
 
 import (
-	"fmt"
 	"os"
 	"runtime"
 	"strconv"
@@ -189,20 +188,20 @@ func validateConfig(c *launcher.Config) error {
 	apikey := c.Headers[honeycombApiKeyHeader]
 	dataset := c.Headers[honeycombDatasetHeader]
 
-	switch len(apikey) {
-	case 0:
-		_, err := fmt.Println(noApiKeyDetectedMessage)
-		return err
-	case 32: // classic
-		if dataset == "" {
-			_, err := fmt.Printf(classicKeyMissingDatasetMessage + "\n", apikey)
-			return err
-		}
-	default:
-		if dataset != "" {
-			_, err := fmt.Println(dontSetADatasetMessageMessage)
-			return err
+	if c.Logger != nil {
+		switch len(apikey) {
+		case 0:
+			c.Logger.Debugf(noApiKeyDetectedMessage)
+		case 32: // classic
+			if dataset == "" {
+				c.Logger.Debugf("%s\n%s", classicKeyMissingDatasetMessage, apikey)
+			}
+		default:
+			if dataset != "" {
+				c.Logger.Debugf(dontSetADatasetMessageMessage)
+			}
 		}
 	}
+
 	return nil
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Messages printed by the SDK should use the provided logger and not print directly to the console.

Not sure on if we should fall back to `fmt.Println` if no logger has been provided? A default one is provided by the launcher which uses `fmt` so it feels like if you override it to `nil` then that is your own rake to step on.

## Short description of the changes

When we print errors with the configuration we now use the configured logger.

## How to verify that this has the expected result
  
run the tests
