### PR TITLE
maint: add smoke test to circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ matrix_goversions: &matrix_goversions
 
 default_goversion: &default_goversion "18"
 
+orbs:
+  bats: circleci/bats@1.0.0
+
 jobs:
   test:
     parameters:
@@ -25,6 +28,32 @@ jobs:
           key: v1-go-mod-{{ checksum "go.sum" }}
           paths:
             - /home/circleci/go/pkg/mod
+
+  smoke_test:
+    machine:
+      image: ubuntu-2004:202107-02
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./
+      - bats/install
+      - run:
+          name: What's the BATS?
+          command: |
+            which bats
+            bats --version
+      - run:
+          name: Smoke Test
+          command: make smoke-sdk
+      - store_test_results:
+          path: ./smoke-tests/
+      - store_artifacts:
+          path: ./smoke-tests/report.xml
+      - store_artifacts:
+          path: ./smoke-tests/collector/data-results
+      - run:
+          name: Extinguish the flames
+          command: make unsmoke
 
   publish_github:
     docker:
@@ -48,6 +77,9 @@ workflows:
     jobs:
       - test:
           <<: *matrix_goversions
+      - smoke_test:
+          requires:
+            - test
 
   build:
     jobs:
@@ -56,10 +88,14 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - smoke_test:
+          requires:
+            - test
       - publish_github:
           context: Honeycomb Secrets for Public Repos
           requires:
             - test
+            - smoke_test
           filters:
             tags:
               only: /^v[0-9].*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,6 @@ workflows:
       - publish_github:
           context: Honeycomb Secrets for Public Repos
           requires:
-            - test
             - smoke_test
           filters:
             tags:


### PR DESCRIPTION
## Which problem is this PR solving?

- closes #106 

## Short description of the changes

Add smoke tests to circleci config. Smoke tests are run in nightly runs with regular test, as well as on builds (requiring test to succeed) and as a requirement for publishing to Github

## How to verify that this has the expected result
  
[check it out in circle](https://app.circleci.com/pipelines/github/honeycombio/honeycomb-opentelemetry-go/309/workflows/64fb5b6a-d1e9-4b5c-83fe-c18c47217c06/jobs/641)! should see passing tests and uploaded artifacts.