### PR TITLE
ci: fix filters for smoke-tests job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,9 @@ workflows:
       - smoke_test:
           requires:
             - test
+          filters:
+            tags:
+              only: /.*/
       - publish_github:
           context: Honeycomb Secrets for Public Repos
           requires:


### PR DESCRIPTION
## Which problem is this PR solving?
Added `filters` for `smoke-tests` job because CircleCI needs filters for every job if there are filters for a single job. This was preventing other steps like `publish-github`.

## Short description of the changes
- Added a filters section that allows smoke tests to run on every push.

## How to verify that this has the expected result
- Smoke tests should run in CI: https://github.com/honeycombio/honeycomb-opentelemetry-go/pull/110/checks?check_run_id=10760320583
  
