### PR TITLE
maint: otel-launcher-go rename to otel-config-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Latest release built with:
 
 ## Where's most of the code?
 
-This package is a _layer_ on top of the core package, which you can find in [here](https://github.com/honeycombio/otel-launcher-go). As such, this package only contains Honeycomb-specific functionality.
+This package is a _layer_ on top of the core package, which you can find in [here](https://github.com/honeycombio/otel-config-go). As such, this package only contains Honeycomb-specific functionality.
 
-Our goal is that the launcher be donated to the [opentelemetry-go-contrib](https://github.com/open-telemetry/opentelemetry-go-contrib) project as a blessed, vendor-neutral way to get started.
+Our goal is to have the `otel-config-go` package be donated to the [opentelemetry-go-contrib](https://github.com/open-telemetry/opentelemetry-go-contrib) project as a blessed, vendor-neutral way to get started.
 
 ## License
 

--- a/examples/baggage/example.go
+++ b/examples/baggage/example.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/honeycombio/honeycomb-opentelemetry-go"
-	"github.com/honeycombio/otel-launcher-go/launcher"
+	"github.com/honeycombio/otel-config-go/otelconfig"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -41,8 +41,8 @@ func main() {
 	})
 	bsp := honeycomb.NewBaggageSpanProcessor()
 
-	shutdown, err := launcher.ConfigureOpenTelemetry(
-		launcher.WithSpanProcessor(dsp, bsp),
+	shutdown, err := otelconfig.ConfigureOpenTelemetry(
+		otelconfig.WithSpanProcessor(dsp, bsp),
 	)
 	defer shutdown()
 

--- a/examples/baggage/go.mod
+++ b/examples/baggage/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/honeycombio/honeycomb-opentelemetry-go v0.5.2
-	github.com/honeycombio/otel-launcher-go v1.7.0
+	github.com/honeycombio/otel-config-go v1.8.0
 	go.opentelemetry.io/otel v1.14.0
 )
 

--- a/examples/baggage/go.sum
+++ b/examples/baggage/go.sum
@@ -134,8 +134,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.12.0 h1:kr3j8iIMR4ywO/O0rvksXaJvauG
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.12.0/go.mod h1:ummNFgdgLhhX7aIiy35vVmQNS0rWXknfPE0qe6fmFXg=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/honeycombio/otel-launcher-go v1.7.0 h1:aIBtiEMo8/L2Br1fR5mwk2J32tlkdsqB8bpwlgTImzQ=
-github.com/honeycombio/otel-launcher-go v1.7.0/go.mod h1:mfI1UuyP3sJZ8aatK77WkSH5wb99ehh3TQXkQk0IWhY=
+github.com/honeycombio/otel-config-go v1.8.0 h1:n25rTbhmNgdtUnaCH1q58UqfLbVrLHXc/LT1XNoaQx0=
+github.com/honeycombio/otel-config-go v1.8.0/go.mod h1:uIk49fSruek3HndJBkS8p+3EBuSeajantKWgA61omEo=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=

--- a/examples/webhook-listener-triggers/go.mod
+++ b/examples/webhook-listener-triggers/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/gorilla/mux v1.8.0
 	github.com/honeycombio/honeycomb-opentelemetry-go v0.5.2
-	github.com/honeycombio/otel-launcher-go v1.7.0
+	github.com/honeycombio/otel-config-go v1.8.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.40.0
 )
 

--- a/examples/webhook-listener-triggers/go.sum
+++ b/examples/webhook-listener-triggers/go.sum
@@ -138,8 +138,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.12.0 h1:kr3j8iIMR4ywO/O0rvksXaJvauG
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.12.0/go.mod h1:ummNFgdgLhhX7aIiy35vVmQNS0rWXknfPE0qe6fmFXg=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/honeycombio/otel-launcher-go v1.7.0 h1:aIBtiEMo8/L2Br1fR5mwk2J32tlkdsqB8bpwlgTImzQ=
-github.com/honeycombio/otel-launcher-go v1.7.0/go.mod h1:mfI1UuyP3sJZ8aatK77WkSH5wb99ehh3TQXkQk0IWhY=
+github.com/honeycombio/otel-config-go v1.8.0 h1:n25rTbhmNgdtUnaCH1q58UqfLbVrLHXc/LT1XNoaQx0=
+github.com/honeycombio/otel-config-go v1.8.0/go.mod h1:uIk49fSruek3HndJBkS8p+3EBuSeajantKWgA61omEo=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=

--- a/examples/webhook-listener-triggers/main.go
+++ b/examples/webhook-listener-triggers/main.go
@@ -14,7 +14,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux"
 
 	"github.com/gorilla/mux"
-	"github.com/honeycombio/otel-launcher-go/launcher"
+	"github.com/honeycombio/otel-config-go/otelconfig"
 )
 
 // Config configures this application
@@ -76,10 +76,10 @@ type App struct {
 }
 
 func main() {
-	shutdown, err := launcher.ConfigureOpenTelemetry(
-		launcher.WithServiceName("webhook-listener-triggers"),
-		launcher.WithMetricsEnabled(false),
-		launcher.WithExporterInsecure(true),
+	shutdown, err := otelconfig.ConfigureOpenTelemetry(
+		otelconfig.WithServiceName("webhook-listener-triggers"),
+		otelconfig.WithMetricsEnabled(false),
+		otelconfig.WithExporterInsecure(true),
 	)
 	defer shutdown()
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/honeycombio/honeycomb-opentelemetry-go
 go 1.18
 
 require (
-	github.com/honeycombio/otel-launcher-go v1.7.0
+	github.com/honeycombio/otel-config-go v1.8.0
 	github.com/stretchr/testify v1.8.2
 	go.opentelemetry.io/otel v1.14.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.12.0 h1:kr3j8iIMR4ywO/O0rvksXaJvauG
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.12.0/go.mod h1:ummNFgdgLhhX7aIiy35vVmQNS0rWXknfPE0qe6fmFXg=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/honeycombio/otel-launcher-go v1.7.0 h1:aIBtiEMo8/L2Br1fR5mwk2J32tlkdsqB8bpwlgTImzQ=
-github.com/honeycombio/otel-launcher-go v1.7.0/go.mod h1:mfI1UuyP3sJZ8aatK77WkSH5wb99ehh3TQXkQk0IWhY=
+github.com/honeycombio/otel-config-go v1.8.0 h1:n25rTbhmNgdtUnaCH1q58UqfLbVrLHXc/LT1XNoaQx0=
+github.com/honeycombio/otel-config-go v1.8.0/go.mod h1:uIk49fSruek3HndJBkS8p+3EBuSeajantKWgA61omEo=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=

--- a/honeycomb.go
+++ b/honeycomb.go
@@ -19,7 +19,7 @@ import (
 	"runtime"
 	"strconv"
 
-	"github.com/honeycombio/otel-launcher-go/launcher"
+	"github.com/honeycombio/otel-config-go/otelconfig"
 
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/sdk/trace"
@@ -36,14 +36,14 @@ const (
 )
 
 func init() {
-	launcher.SetVendorOptions = getVendorOptionSetters
-	launcher.ValidateConfig = validateConfig
-	launcher.DefaultExporterEndpoint = defaultExporterEndpoint
+	otelconfig.SetVendorOptions = getVendorOptionSetters
+	otelconfig.ValidateConfig = validateConfig
+	otelconfig.DefaultExporterEndpoint = defaultExporterEndpoint
 }
 
 // WithHoneycomb() sets the destination for traces and metrics to Honeycomb's API endpoint.
-func WithHoneycomb() launcher.Option {
-	return func(c *launcher.Config) {
+func WithHoneycomb() otelconfig.Option {
+	return func(c *otelconfig.Config) {
 		c.ResourceAttributes[honeycombDistroVersionKey] = Version
 		c.ResourceAttributes[honeycombDistroRuntimeVersionKey] = runtime.Version()
 		c.Headers[otlpProtoVersionHeader] = otlpProtoVersionValue
@@ -51,63 +51,63 @@ func WithHoneycomb() launcher.Option {
 }
 
 // WithApiKey() sets the authorization header appropriately for sending to Honeycomb's API endpoint.
-func WithApiKey(apikey string) launcher.Option {
-	return func(c *launcher.Config) {
+func WithApiKey(apikey string) otelconfig.Option {
+	return func(c *otelconfig.Config) {
 		c.Headers[honeycombApiKeyHeader] = apikey
 	}
 }
 
 // WithTracesApiKey() sets the authorization header appropriately for sending traces telemetry to Honeycomb's API endpoint.
-func WithTracesApiKey(apikey string) launcher.Option {
-	return func(c *launcher.Config) {
+func WithTracesApiKey(apikey string) otelconfig.Option {
+	return func(c *otelconfig.Config) {
 		c.TracesHeaders[honeycombApiKeyHeader] = apikey
 	}
 }
 
 // WithMetricsApiKey() sets the authorization header appropriately for sending metrics telemetry to Honeycomb's API endpoint.
-func WithMetricsApiKey(apikey string) launcher.Option {
-	return func(c *launcher.Config) {
+func WithMetricsApiKey(apikey string) otelconfig.Option {
+	return func(c *otelconfig.Config) {
 		c.MetricsHeaders[honeycombApiKeyHeader] = apikey
 	}
 }
 
 // WithDataset() sets the header for routing telemetry to a named dataset at Honeycomb. (For trace data in Classic teams and for metrics only.)
-func WithDataset(dataset string) launcher.Option {
-	return func(c *launcher.Config) {
+func WithDataset(dataset string) otelconfig.Option {
+	return func(c *otelconfig.Config) {
 		c.Headers[honeycombDatasetHeader] = dataset
 	}
 }
 
 // WithTracesDataset() sets the header for routing traces telemetry to a named dataset at Honeycomb.
-func WithTracesDataset(dataset string) launcher.Option {
-	return func(c *launcher.Config) {
+func WithTracesDataset(dataset string) otelconfig.Option {
+	return func(c *otelconfig.Config) {
 		c.TracesHeaders[honeycombDatasetHeader] = dataset
 	}
 }
 
 // WithMetricsDataset() sets the header for routing metrics telemetry to a named dataset at Honeycomb.
-func WithMetricsDataset(dataset string) launcher.Option {
-	return func(c *launcher.Config) {
+func WithMetricsDataset(dataset string) otelconfig.Option {
+	return func(c *otelconfig.Config) {
 		c.MetricsHeaders[honeycombDatasetHeader] = dataset
 	}
 }
 
 // WithSampler() sets the sampler used to sample trace spans using a Honeycomb sample rate.
 // Sample rate is expressed as 1/X where x is the population size.
-func WithSampler(sampleRate int) launcher.Option {
-	return func(c *launcher.Config) {
+func WithSampler(sampleRate int) otelconfig.Option {
+	return func(c *otelconfig.Config) {
 		c.Sampler = NewDeterministicSampler(sampleRate)
 	}
 }
 
 // WithDebugSpanExporter() determines whether a debug (stdout) traces exporter should be configured.
-func WithDebugSpanExporter() launcher.Option {
+func WithDebugSpanExporter() otelconfig.Option {
 	spanExporter, _ := stdouttrace.New(stdouttrace.WithPrettyPrint())
-	return launcher.WithSpanProcessor(trace.NewSimpleSpanProcessor(spanExporter))
+	return otelconfig.WithSpanProcessor(trace.NewSimpleSpanProcessor(spanExporter))
 }
 
-func getVendorOptionSetters() []launcher.Option {
-	opts := []launcher.Option{
+func getVendorOptionSetters() []otelconfig.Option {
+	opts := []otelconfig.Option{
 		WithHoneycomb(),
 	}
 
@@ -115,13 +115,13 @@ func getVendorOptionSetters() []launcher.Option {
 	serviceName := "unknown_service:go"
 
 	if endpoint := os.Getenv("HONEYCOMB_API_ENDPOINT"); endpoint != "" {
-		opts = append(opts, launcher.WithExporterEndpoint(endpoint))
+		opts = append(opts, otelconfig.WithExporterEndpoint(endpoint))
 	}
 	if endpoint := os.Getenv("HONEYCOMB_TRACES_API_ENDPOINT"); endpoint != "" {
-		opts = append(opts, launcher.WithTracesExporterEndpoint(endpoint))
+		opts = append(opts, otelconfig.WithTracesExporterEndpoint(endpoint))
 	}
 	if endpoint := os.Getenv("HONEYCOMB_METRICS_API_ENDPOINT"); endpoint != "" {
-		opts = append(opts, launcher.WithMetricsExporterEndpoint(endpoint))
+		opts = append(opts, otelconfig.WithMetricsExporterEndpoint(endpoint))
 	}
 	if apikey = os.Getenv("HONEYCOMB_API_KEY"); apikey != "" {
 		opts = append(opts, WithApiKey(apikey))
@@ -154,19 +154,19 @@ func getVendorOptionSetters() []launcher.Option {
 		enabled, _ := strconv.ParseBool(enabledStr)
 		if enabled {
 			opts = append(opts, WithDebugSpanExporter())
-			opts = append(opts, launcher.WithLogLevel("debug"))
+			opts = append(opts, otelconfig.WithLogLevel("debug"))
 		}
 	}
 
 	if serviceName = os.Getenv("OTEL_SERVICE_NAME"); serviceName == "" {
-		opts = append(opts, launcher.WithServiceName("unknown_service:go"))
+		opts = append(opts, otelconfig.WithServiceName("unknown_service:go"))
 	}
 
 	if enableLocalVisualizationsStr := os.Getenv("HONEYCOMB_ENABLE_LOCAL_VISUALIZATIONS"); enableLocalVisualizationsStr != "" {
 		enabled, _ := strconv.ParseBool(enableLocalVisualizationsStr)
 		if enabled {
 			exporter, _ := NewSpanLinkExporter(apikey, serviceName)
-			sp := launcher.WithSpanProcessor(trace.NewSimpleSpanProcessor(exporter))
+			sp := otelconfig.WithSpanProcessor(trace.NewSimpleSpanProcessor(exporter))
 			opts = append(opts, sp)
 		}
 	}
@@ -179,11 +179,11 @@ func getVendorOptionSetters() []launcher.Option {
 			metricsEnabled = true
 		}
 	}
-	opts = append(opts, launcher.WithMetricsEnabled(metricsEnabled))
+	opts = append(opts, otelconfig.WithMetricsEnabled(metricsEnabled))
 	return opts
 }
 
-func validateConfig(c *launcher.Config) error {
+func validateConfig(c *otelconfig.Config) error {
 	apikey := c.Headers[honeycombApiKeyHeader]
 	dataset := c.Headers[honeycombDatasetHeader]
 

--- a/honeycomb_test.go
+++ b/honeycomb_test.go
@@ -18,14 +18,14 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/honeycombio/otel-launcher-go/launcher"
+	"github.com/honeycombio/otel-config-go/otelconfig"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
 )
 
-func freshConfig() *launcher.Config {
-	return &launcher.Config{
+func freshConfig() *otelconfig.Config {
+	return &otelconfig.Config{
 		TracesExporterEndpoint:          "",
 		TracesExporterEndpointInsecure:  false,
 		TracesEnabled:                   false,
@@ -45,7 +45,7 @@ func freshConfig() *launcher.Config {
 		SpanProcessors:                  []trace.SpanProcessor{},
 		Resource:                        &resource.Resource{},
 		Logger:                          nil,
-		ShutdownFunctions:               []func(c *launcher.Config) error{},
+		ShutdownFunctions:               []func(c *otelconfig.Config) error{},
 		Sampler:                         trace.AlwaysSample(),
 	}
 }
@@ -238,11 +238,11 @@ func TestServiceNameDefaultsToUnknownServiceWhenNotSet(t *testing.T) {
 
 func TestSettingDebugAlsoSetsLogLevelToDebug(t *testing.T) {
 	t.Setenv("DEBUG", "true")
-	launcher.ValidateConfig = func(c *launcher.Config) error {
+	otelconfig.ValidateConfig = func(c *otelconfig.Config) error {
 		assert.Equal(t, c.LogLevel, "debug")
 		return nil
 	}
-	_, err := launcher.ConfigureOpenTelemetry()
+	_, err := otelconfig.ConfigureOpenTelemetry()
 	assert.Nil(t, err)
 }
 
@@ -251,13 +251,13 @@ func TestCanSetEndpointsUsingHoneycombEnvVars(t *testing.T) {
 	t.Setenv("HONEYCOMB_TRACES_API_ENDPOINT", "traces-endpoint")
 	t.Setenv("HONEYCOMB_METRICS_API_ENDPOINT", "metrics-endpoint")
 
-	launcher.ValidateConfig = func(c *launcher.Config) error {
+	otelconfig.ValidateConfig = func(c *otelconfig.Config) error {
 		assert.Equal(t, "generic-endpoint", c.ExporterEndpoint)
 		assert.Equal(t, "traces-endpoint", c.TracesExporterEndpoint)
 		assert.Equal(t, "metrics-endpoint", c.MetricsExporterEndpoint)
 		return nil
 	}
-	_, err := launcher.ConfigureOpenTelemetry()
+	_, err := otelconfig.ConfigureOpenTelemetry()
 	assert.Nil(t, err)
 }
 
@@ -266,13 +266,13 @@ func TestCanSetEndpointsUsingOTelEnvVars(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "otel-traces-endpoint")
 	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "otel-metrics-endpoint")
 
-	launcher.ValidateConfig = func(c *launcher.Config) error {
+	otelconfig.ValidateConfig = func(c *otelconfig.Config) error {
 		assert.Equal(t, "otel-generic-endpoint", c.ExporterEndpoint)
 		assert.Equal(t, "otel-traces-endpoint", c.TracesExporterEndpoint)
 		assert.Equal(t, "otel-metrics-endpoint", c.MetricsExporterEndpoint)
 		return nil
 	}
-	_, err := launcher.ConfigureOpenTelemetry()
+	_, err := otelconfig.ConfigureOpenTelemetry()
 	assert.Nil(t, err)
 }
 
@@ -282,32 +282,32 @@ func TestCanSetTracesAndMetricsSpecificHeaders(t *testing.T) {
 	t.Setenv("HONEYCOMB_METRICS_APIKEY", "metrics-apikey")
 	t.Setenv("HONEYCOMB_METRICS_DATASET", "metrics-dataset")
 
-	launcher.ValidateConfig = func(c *launcher.Config) error {
+	otelconfig.ValidateConfig = func(c *otelconfig.Config) error {
 		assert.Equal(t, "traces-apikey", c.TracesHeaders[honeycombApiKeyHeader])
 		assert.Equal(t, "traces-dataset", c.TracesHeaders[honeycombDatasetHeader])
 		assert.Equal(t, "metrics-apikey", c.MetricsHeaders[honeycombApiKeyHeader])
 		assert.Equal(t, "metrics-dataset", c.MetricsHeaders[honeycombDatasetHeader])
 		return nil
 	}
-	_, err := launcher.ConfigureOpenTelemetry()
+	_, err := otelconfig.ConfigureOpenTelemetry()
 	assert.Nil(t, err)
 }
 
 func TestMetricsAreDisabledByDefault(t *testing.T) {
 	// disabled by default
-	launcher.ValidateConfig = func(c *launcher.Config) error {
+	otelconfig.ValidateConfig = func(c *otelconfig.Config) error {
 		assert.False(t, c.MetricsEnabled)
 		return nil
 	}
-	_, err := launcher.ConfigureOpenTelemetry()
+	_, err := otelconfig.ConfigureOpenTelemetry()
 	assert.Nil(t, err)
 
 	// can be enabled
 	t.Setenv("OTEL_METRICS_ENABLED", "true")
-	launcher.ValidateConfig = func(c *launcher.Config) error {
+	otelconfig.ValidateConfig = func(c *otelconfig.Config) error {
 		assert.True(t, c.MetricsEnabled)
 		return nil
 	}
-	_, err = launcher.ConfigureOpenTelemetry()
+	_, err = otelconfig.ConfigureOpenTelemetry()
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
## Which problem is this PR solving?
`otel-launcher-go` has been renamed to `otel-config-go`, this PR handles that name change

## Short description of the changes
- Use `otel-config-go` package instead of `otel-launcher-go` package
- Rename `launcher` to `otelconfig` everywhere
  
