### PR TITLE
maint: update ubuntu and collector versions in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
 
   smoke_test:
     machine:
-      image: ubuntu-2004:202107-02
+      image: ubuntu-2004:2023.04.2
     steps:
       - checkout
       - attach_workspace:

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ Thumbs.db
 *.iml
 *.so
 coverage.*
+
+# test stuff
+smoke-tests/collector/data.json
+smoke-tests/collector/data-results/*.json
+smoke-tests/report.xml

--- a/smoke-tests/docker-compose.yml
+++ b/smoke-tests/docker-compose.yml
@@ -20,7 +20,7 @@ x-app-base: &app_base
 
 services:
   collector:
-    image: otel/opentelemetry-collector:0.52.0
+    image: otel/opentelemetry-collector:0.81.0
     command: ["--config=/etc/otel-collector-config.yaml"]
     volumes:
       - "./collector/otel-collector-config.yaml:/etc/otel-collector-config.yaml"


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #150 

## Short description of the changes

- update ubuntu to newer image for smoke test (this was the actual fix)
- update collector to newer version
- gitignore smoke test output from local tests

## How to verify that this has the expected result
  
all tests pass in Circle ([success](https://app.circleci.com/pipelines/github/honeycombio/honeycomb-opentelemetry-go/580/workflows/7fb6e477-ce51-4137-869c-4ee0d44c1f06/jobs/1520)) and with local tests