### PR TITLE
maint: add label type:dependencies to maintenance category for release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -18,6 +18,7 @@ changelog:
     - title: 🛠 Maintenance
       labels:
         - "type: maintenance"
+        - "type: dependencies"
     - title: 🤷 Other Changes
       labels:
         - "*"


### PR DESCRIPTION
## Which problem is this PR solving?

- auto-generated release notes put all dependency bumps into "other changes"

## Short description of the changes

- add label type:dependencies to maintenance category for release notes

## How to verify that this has the expected result
  
next time we auto-generate notes for a release that includes a dependabot update, it should show up in the maintenance category