### PR TITLE
maint: add dependabot groups and include example directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,4 +16,31 @@ updates:
     commit-message:
       prefix: "maint"
       include: "scope"
-      
+    groups:
+      otel-dependencies:
+        patterns:
+          - "go.opentelemetry.io/otel/*"
+
+  - package-ecosystem: "gomod"
+    directory: "/examples/baggage"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "type: dependencies"
+    reviewers:
+      - "honeycombio/telemetry-team"
+    commit-message:
+      prefix: "maint"
+      include: "scope"
+
+  - package-ecosystem: "gomod"
+    directory: "/examples/webhook-listener-triggers"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "type: dependencies"
+    reviewers:
+      - "honeycombio/telemetry-team"
+    commit-message:
+      prefix: "maint"
+      include: "scope"


### PR DESCRIPTION
## Which problem is this PR solving?

- easier dependency updates

## Short description of the changes

- add groups for main package
- add example dirs to dependabot

## How to verify that this has the expected result
  
next dependabots should group otel dependencies, and also include updates for examples