### PR TITLE
maint: add labels to release.yml for auto-generated grouping

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -19,6 +19,7 @@ changelog:
       labels:
         - "type: maintenance"
         - "type: dependencies"
+        - "type: documentation"
     - title: 🤷 Other Changes
       labels:
         - "*"


### PR DESCRIPTION
update release.yml that gets used for generating release notes to include labels of type: dependencies and type: documentation