### PR TITLE
maint: Update ubuntu image in workflows to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,8 @@ jobs:
             - /home/circleci/go/pkg/mod
 
   smoke_test:
-    runs-on: ubuntu-24.04
+    docker:
+      - image: ubuntu-24.04
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
 
   smoke_test:
     machine:
-      image: ubuntu-24.04
+      image: ubuntu-2204:2024.01.1
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,7 @@ jobs:
             - /home/circleci/go/pkg/mod
 
   smoke_test:
-    machine:
-      image: ubuntu-24.04
+    runs-on: ubuntu-24.04
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
 
   smoke_test:
     machine:
-      image: ubuntu-2004:2023.04.2
+      image: ubuntu-24.04
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ jobs:
             - /home/circleci/go/pkg/mod
 
   smoke_test:
-    docker:
-      - image: ubuntu-24.04
+    machine:
+      image: ubuntu-24.04
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
## Which problem is this PR solving?
Older ubuntu images used in our workflows are being marked as deprecated. We need to update to newer ones.

## Short description of the changes
- Update workflows images to use `ubuntu-2204:2024.01.1` image

